### PR TITLE
for Bitcoin Core v23.0

### DIFF
--- a/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
+++ b/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
@@ -32,7 +32,7 @@ sudo systemctl restart bitcoind
 EPS needs a wallet in Bitcoin Core. Create one if it is not already present. From bitcoin version 23.0 the default wallet type created is descriptor, which does not support importing adresses. To prevent this you need to add `descriptors=false`
 
 ```bash
-bitcoin-cli createwallet electrumpersonalserver true descriptors=false
+bitcoin-cli -named createwallet wallet_name="electrumpersonalserver" disable_private_keys=true descriptors=false
 ```
 
 Finally, create the following folder in your homedir and go into it.

--- a/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
+++ b/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
@@ -29,10 +29,10 @@ If it is not there already, add it, save the file (using `Ctrl + X`) and restart
 sudo systemctl restart bitcoind
 ```
 
-EPS needs a wallet in Bitcoin Core. Create one if it is not already present.
+EPS needs a wallet in Bitcoin Core. Create one if it is not already present. From bitcoin version 23.0 the default wallet type created is descriptor, which does not support importing adresses. To prevent this you need to add `descriptors=false`
 
 ```bash
-bitcoin-cli createwallet electrumpersonalserver true true "" false false true
+bitcoin-cli createwallet electrumpersonalserver descriptors=false
 ```
 
 Finally, create the following folder in your homedir and go into it.

--- a/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
+++ b/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
@@ -32,7 +32,7 @@ sudo systemctl restart bitcoind
 EPS needs a wallet in Bitcoin Core. Create one if it is not already present.
 
 ```bash
-bitcoin-cli createwallet electrumpersonalserver true
+bitcoin-cli createwallet electrumpersonalserver true true "" false false true
 ```
 
 Finally, create the following folder in your homedir and go into it.

--- a/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
+++ b/pages/bitcoin-core-extensions/electrum-personal-server.en.mdx
@@ -32,7 +32,7 @@ sudo systemctl restart bitcoind
 EPS needs a wallet in Bitcoin Core. Create one if it is not already present. From bitcoin version 23.0 the default wallet type created is descriptor, which does not support importing adresses. To prevent this you need to add `descriptors=false`
 
 ```bash
-bitcoin-cli createwallet electrumpersonalserver descriptors=false
+bitcoin-cli createwallet electrumpersonalserver true descriptors=false
 ```
 
 Finally, create the following folder in your homedir and go into it.

--- a/pages/bitcoin-core-extensions/electrum-personal-server.nl.mdx
+++ b/pages/bitcoin-core-extensions/electrum-personal-server.nl.mdx
@@ -32,7 +32,7 @@ sudo systemctl restart bitcoind
 EPS heeft een wallet nodig in Bitcoin Core. Maak deze aan als deze nog niet aanwezig is. Vanaf bitcoin versie 23.0 de default wallet die gemaakt wordt is een descriptor wallet. Deze support het importeren van adressen niet. Om dit op te lossen moet je het argument `descriptors=false` toevoegen.
 
 ```bash
-bitcoin-cli createwallet electrumpersonalserver descriptors=false
+bitcoin-cli createwallet electrumpersonalserver true descriptors=false
 ```
 
 Maak tot slot de volgende map in je homedir aan en ga erin.

--- a/pages/bitcoin-core-extensions/electrum-personal-server.nl.mdx
+++ b/pages/bitcoin-core-extensions/electrum-personal-server.nl.mdx
@@ -29,10 +29,10 @@ Als dat nog niet het geval is voeg je deze toe, sla je het bestand op \(met `Ctr
 sudo systemctl restart bitcoind
 ```
 
-EPS heeft een wallet nodig in Bitcoin Core. Maak deze aan als deze nog niet aanwezig is.
+EPS heeft een wallet nodig in Bitcoin Core. Maak deze aan als deze nog niet aanwezig is. Vanaf bitcoin versie 23.0 de default wallet die gemaakt wordt is een descriptor wallet. Deze support het importeren van adressen niet. Om dit op te lossen moet je het argument `descriptors=false` toevoegen.
 
 ```bash
-bitcoin-cli createwallet electrumpersonalserver true
+bitcoin-cli createwallet electrumpersonalserver descriptors=false
 ```
 
 Maak tot slot de volgende map in je homedir aan en ga erin.

--- a/pages/bitcoin-core-extensions/electrum-personal-server.nl.mdx
+++ b/pages/bitcoin-core-extensions/electrum-personal-server.nl.mdx
@@ -32,7 +32,7 @@ sudo systemctl restart bitcoind
 EPS heeft een wallet nodig in Bitcoin Core. Maak deze aan als deze nog niet aanwezig is. Vanaf bitcoin versie 23.0 de default wallet die gemaakt wordt is een descriptor wallet. Deze support het importeren van adressen niet. Om dit op te lossen moet je het argument `descriptors=false` toevoegen.
 
 ```bash
-bitcoin-cli createwallet electrumpersonalserver true descriptors=false
+bitcoin-cli -named createwallet wallet_name="electrumpersonalserver" disable_private_keys=true descriptors=false
 ```
 
 Maak tot slot de volgende map in je homedir aan en ga erin.


### PR DESCRIPTION
the create wallet command is different because otherwise a descriptor wallet is created