### PR TITLE
Install rust and cargo with rustup

### DIFF
--- a/pages/bitcoin-core-extensions/electrs.en.mdx
+++ b/pages/bitcoin-core-extensions/electrs.en.mdx
@@ -15,7 +15,19 @@ Electrs waits for Bitcoin Core to finish synchronizing. So you can't use Electrs
 Start by installing the dependencies.
 
 ```bash
-sudo apt install -y clang cmake cargo
+sudo apt install -y clang cmake
+```
+
+Install Rust and Cargo
+
+```bash
+curl https://sh.rustup.rs -sSf | sh
+```
+
+Source the corresponding env file
+
+```bash
+. "$HOME/.cargo/env"
 ```
 
 Make sure you are in the home directory and get Electrs in via Git.


### PR DESCRIPTION
apt installs an older version of cargo which is now incompatible, use `rustup` to install the up-to-date version